### PR TITLE
Rename web page titles in documentation

### DIFF
--- a/website/src/components/App.re
+++ b/website/src/components/App.re
@@ -28,7 +28,7 @@ let make =
                )>
                <BsReactHelmet>
                  <title>
-                   {("BsReactNative " ++ pageData.title)->React.string}
+                   {("ReactNative." ++ pageData.title)->React.string}
                  </title>
                </BsReactHelmet>
                <PageContent pageData />


### PR DESCRIPTION
Lots of exciting changes while I've been away.

I will try to contribute documentation for a few more components or APIs before the release. In the meanwhile, I noticed webpage titles still had `BsReactNative`.