### PR TITLE
correct success callback for ImagePickerIOS methods

### DIFF
--- a/reason-react-native/src/apis/ImagePickerIOS.re
+++ b/reason-react-native/src/apis/ImagePickerIOS.re
@@ -21,7 +21,7 @@ external selectDialogConfig:
 external openCameraDialog:
   (
     ~config: cameraDialogConfig,
-    ~onSuccess: imageUri => unit,
+    ~onSuccess: (imageUri, ~height: float, ~width: float, unit) => unit,
     ~onError: 'error => unit
   ) =>
   unit =
@@ -31,7 +31,7 @@ external openCameraDialog:
 external openSelectDialog:
   (
     ~config: selectDialogConfig,
-    ~onSuccess: imageUri => unit,
+    ~onSuccess: (imageUri, ~height: float, ~width: float, unit) => unit,
     ~onError: 'error => unit
   ) =>
   unit =


### PR DESCRIPTION
I've noticed a mistake with the type of the success callback function for `openSelectDialog` and `openCameraDialog` methods, and this PR corrects that.

While ImagePickerIOS is outdated, it is still part of React Native (even in 0.60, as it seems) and the official documentation does not clearly communicate that it should be removed soon.

I didn't update documentation, because I'll add it soon.