### PR TITLE
Transformer Deg should be encoded to float instead of percentage.

### DIFF
--- a/bs-react-native-jsx3-compat/src/Internals.re
+++ b/bs-react-native-jsx3-compat/src/Internals.re
@@ -16,5 +16,5 @@ module Encoder = {
 
   let pct = f => string(Printf.sprintf("%.2f%%", f));
 
-  let deg = f => string(Printf.sprintf("%.2f%%", f) ++ "deg");
+  let deg = f => string(Printf.sprintf("%.2f", f) ++ "deg");
 };

--- a/bs-react-native/src/Internals.bs.js
+++ b/bs-react-native/src/Internals.bs.js
@@ -25,12 +25,9 @@ function deg(f) {
                       /* Float_f */0,
                       /* No_padding */0,
                       /* Lit_precision */[2],
-                      /* Char_literal */Block.__(12, [
-                          /* "%" */37,
-                          /* End_of_format */0
-                        ])
+                      /* End_of_format */0
                     ]),
-                  "%.2f%%"
+                  "%.2f"
                 ]), f) + "deg";
 }
 

--- a/bs-react-native/src/Internals.re
+++ b/bs-react-native/src/Internals.re
@@ -16,5 +16,5 @@ module Encoder = {
 
   let pct = f => string(Printf.sprintf("%.2f%%", f));
 
-  let deg = f => string(Printf.sprintf("%.2f%%", f) ++ "deg");
+  let deg = f => string(Printf.sprintf("%.2f", f) ++ "deg");
 };


### PR DESCRIPTION
There a subtle bug because we are encoding Deg(45.) to percentage, making it crash in android.

The IOS native seems to be resilient enough to handle it and transform it to 45 degrees, but android JS crashes at runtime when you open a screen with rotate(Deg(..))