### PR TITLE
Disable warning 105 (inferred JS names in external definitions)

### DIFF
--- a/reason-react-native/bsconfig.json
+++ b/reason-react-native/bsconfig.json
@@ -16,6 +16,6 @@
       "subdirs": true
     }
   ],
-  "bsc-flags": ["-bs-no-version-header", "-warn-error @a"],
+  "bsc-flags": ["-bs-no-version-header", "-warn-error @a", "-w @a-105"],
   "bs-dependencies": ["reason-react"]
 }


### PR DESCRIPTION
In recent BuckleSscript releases, warning 105 has been defined for inferred JS names in external definitions. For more information, you may refer to the relevant [post](https://bucklescript.github.io/blog/#a-new-warning-number-105) on their blog.

Thus, a definition such as
```
[@bs.module "react-native"] [@bs.scope "Easing"] external linear: t = "";
```
leads to a warning that reads

> the external name is inferred from val name is unsafe from refactoring when changing value name

We could go through the codebase to specify the JS name for all such definitions (which would be almost the entire codebase) or we could revise `bsconfig.json` to ignore warning 105.

I did not take the high road...