### PR TITLE
Add AppRegistry.registerHeadlessTask

### DIFF
--- a/reason-react-native/src/apis/AppRegistry.md
+++ b/reason-react-native/src/apis/AppRegistry.md
@@ -9,6 +9,11 @@ wip: true
 external registerComponent: (string, unit => React.component('a)) => unit =
   "";
 
+type task('data) = 'data => Js.Promise.t(unit);
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external registerHeadlessTask: (string, unit => task('data)) => unit = "";
+
 // react-native-web
 type app = {
   .

--- a/reason-react-native/src/apis/AppRegistry.re
+++ b/reason-react-native/src/apis/AppRegistry.re
@@ -2,6 +2,11 @@
 external registerComponent: (string, unit => React.component('a)) => unit =
   "";
 
+type task('data) = 'data => Js.Promise.t(unit);
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external registerHeadlessTask: (string, unit => task('data)) => unit = "";
+
 // react-native-web
 type app = {
   .


### PR DESCRIPTION
This PR adds the `AppRegistry.registerHeadlessTask` function.

There are more AppRegistry functions missing though, see https://facebook.github.io/react-native/docs/appregistry. These are probably rarely used, but I will file an issue.