### PR TITLE
add missing AppRegistry functions

### DIFF
--- a/reason-react-native/src/apis/AppRegistry.md
+++ b/reason-react-native/src/apis/AppRegistry.md
@@ -5,6 +5,11 @@ wip: true
 ---
 
 ```reason
+type appKey = string;
+type section = string;
+type taskId = float;
+type taskKey = string;
+
 type task('data) = 'data => Js.Promise.t(unit);
 type taskProvider('data) = unit => task('data);
 type taskCanceller = unit => unit;
@@ -39,18 +44,18 @@ type runnable('a) = {
 
 type registry('a) = {
   .
-  "sections": array(string),
+  "sections": array(section),
   "runnables": Js.Dict.t(runnable('a)),
 };
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external getAppKeys: unit => array(string) = "";
+external getAppKeys: unit => array(appKey) = "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
 external getRegistry: unit => registry('a) = "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external getRunnable: string => Js.Nullable.t(runnable('a)) = "";
+external getRunnable: appKey => option(runnable('a)) = "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
 external getSectionKeys: unit => array(string) = "";
@@ -60,29 +65,29 @@ external getSections: unit => Js.Dict.t(runnable('a)) = "";
 
 // multiple externals
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external registerComponent: (string, componentProvider('a)) => unit = "";
+external registerComponent: (appKey, componentProvider('a)) => unit = "";
 
 // multiple externals
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
 external registerComponentWithSection:
-  (string, componentProvider('a), string) => unit =
+  (appKey, componentProvider('a), section) => unit =
   "registerComponent";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
 external registerConfig: array(appConfig) => unit = "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external registerRunnable: (string, appParameters => unit) => string = "";
+external registerRunnable: (appKey, appParameters => unit) => string = "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external registerSection: (string, componentProvider('a)) => unit = "";
+external registerSection: (appKey, componentProvider('a)) => unit = "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external runApplication: (string, 'a) => unit = "";
+external runApplication: (appKey, 'a) => unit = "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
 external setWrapperComponentProvider:
-  Js.Nullable.t(wrapperComponentProvider('a, 'b)) => unit =
+  wrapperComponentProvider('a, 'b) => unit =
   "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
@@ -90,18 +95,18 @@ external unmountApplicationComponentAtRootTag: string => unit = "";
 
 // Android only
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external cancelHeadlessTask: (float, string) => unit = "";
+external cancelHeadlessTask: (taskId, taskKey) => unit = "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
 external registerCancellableHeadlessTask:
-  (string, taskProvider('data), taskCancelProvider) => unit =
+  (taskKey, taskProvider('data), taskCancelProvider) => unit =
   "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external registerHeadlessTask: (string, taskProvider('data)) => unit = "";
+external registerHeadlessTask: (taskKey, taskProvider('data)) => unit = "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external startHeadlessTask: (float, string, 'a) => unit = "";
+external startHeadlessTask: (taskId, taskKey, 'data) => unit = "";
 
 // react-native-web
 type app = {

--- a/reason-react-native/src/apis/AppRegistry.md
+++ b/reason-react-native/src/apis/AppRegistry.md
@@ -5,14 +5,103 @@ wip: true
 ---
 
 ```reason
-[@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external registerComponent: (string, unit => React.component('a)) => unit =
+type task('data) = 'data => Js.Promise.t(unit);
+type taskProvider('data) = unit => task('data);
+type taskCanceller = unit => unit;
+type taskCancelProvider = unit => taskCanceller;
+
+type componentProvider('a) = unit => React.component('a);
+type wrapperComponentProvider('a, 'b) = 'b => React.component('a);
+
+type appParameters;
+
+external asAppParameters: 'a => appParameters = "%identity";
+
+type appConfig;
+
+[@bs.obj]
+external appConfig:
+  (
+    ~appKey: string,
+    ~component: componentProvider('a)=?,
+    ~run: appParameters => unit=?,
+    ~section: bool=?,
+    unit
+  ) =>
+  appConfig =
   "";
 
-type task('data) = 'data => Js.Promise.t(unit);
+type runnable('a) = {
+  .
+  "component": Js.Nullable.t(componentProvider('a)),
+  "run": appParameters => unit,
+};
+
+type registry('a) = {
+  .
+  "sections": array(string),
+  "runnables": Js.Dict.t(runnable('a)),
+};
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external registerHeadlessTask: (string, unit => task('data)) => unit = "";
+external getAppKeys: unit => array(string) = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external getRegistry: unit => registry('a) = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external getRunnable: string => Js.Nullable.t(runnable('a)) = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external getSectionKeys: unit => array(string) = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external getSections: unit => Js.Dict.t(runnable('a)) = "";
+
+// multiple externals
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external registerComponent: (string, componentProvider('a)) => unit = "";
+
+// multiple externals
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external registerComponentWithSection:
+  (string, componentProvider('a), string) => unit =
+  "registerComponent";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external registerConfig: array(appConfig) => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external registerRunnable: (string, appParameters => unit) => string = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external registerSection: (string, componentProvider('a)) => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external runApplication: (string, 'a) => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external setWrapperComponentProvider:
+  Js.Nullable.t(wrapperComponentProvider('a, 'b)) => unit =
+  "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external unmountApplicationComponentAtRootTag: string => unit = "";
+
+// Android only
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external cancelHeadlessTask: (float, string) => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external registerCancellableHeadlessTask:
+  (string, taskProvider('data), taskCancelProvider) => unit =
+  "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external registerHeadlessTask: (string, taskProvider('data)) => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external startHeadlessTask: (float, string, 'a) => unit = "";
 
 // react-native-web
 type app = {
@@ -21,7 +110,6 @@ type app = {
   [@bs.meth] "getStyleElement": unit => React.element,
 };
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external getApplication: (string, {. "initialProps": 'a}) => app =
-  "";
+external getApplication: (string, {. "initialProps": 'a}) => app = "";
 
 ```

--- a/reason-react-native/src/apis/AppRegistry.re
+++ b/reason-react-native/src/apis/AppRegistry.re
@@ -1,11 +1,100 @@
-[@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external registerComponent: (string, unit => React.component('a)) => unit =
+type task('data) = 'data => Js.Promise.t(unit);
+type taskProvider('data) = unit => task('data);
+type taskCanceller = unit => unit;
+type taskCancelProvider = unit => taskCanceller;
+
+type componentProvider('a) = unit => React.component('a);
+type wrapperComponentProvider('a, 'b) = 'b => React.component('a);
+
+type appParameters;
+
+external asAppParameters: 'a => appParameters = "%identity";
+
+type appConfig;
+
+[@bs.obj]
+external appConfig:
+  (
+    ~appKey: string,
+    ~component: componentProvider('a)=?,
+    ~run: appParameters => unit=?,
+    ~section: bool=?,
+    unit
+  ) =>
+  appConfig =
   "";
 
-type task('data) = 'data => Js.Promise.t(unit);
+type runnable('a) = {
+  .
+  "component": Js.Nullable.t(componentProvider('a)),
+  "run": appParameters => unit,
+};
+
+type registry('a) = {
+  .
+  "sections": array(string),
+  "runnables": Js.Dict.t(runnable('a)),
+};
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external registerHeadlessTask: (string, unit => task('data)) => unit = "";
+external getAppKeys: unit => array(string) = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external getRegistry: unit => registry('a) = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external getRunnable: string => Js.Nullable.t(runnable('a)) = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external getSectionKeys: unit => array(string) = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external getSections: unit => Js.Dict.t(runnable('a)) = "";
+
+// multiple externals
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external registerComponent: (string, componentProvider('a)) => unit = "";
+
+// multiple externals
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external registerComponentWithSection:
+  (string, componentProvider('a), string) => unit =
+  "registerComponent";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external registerConfig: array(appConfig) => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external registerRunnable: (string, appParameters => unit) => string = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external registerSection: (string, componentProvider('a)) => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external runApplication: (string, 'a) => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external setWrapperComponentProvider:
+  Js.Nullable.t(wrapperComponentProvider('a, 'b)) => unit =
+  "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external unmountApplicationComponentAtRootTag: string => unit = "";
+
+// Android only
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external cancelHeadlessTask: (float, string) => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external registerCancellableHeadlessTask:
+  (string, taskProvider('data), taskCancelProvider) => unit =
+  "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external registerHeadlessTask: (string, taskProvider('data)) => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "AppRegistry"]
+external startHeadlessTask: (float, string, 'a) => unit = "";
 
 // react-native-web
 type app = {

--- a/reason-react-native/src/apis/AppRegistry.re
+++ b/reason-react-native/src/apis/AppRegistry.re
@@ -1,3 +1,8 @@
+type appKey = string;
+type section = string;
+type taskId = float;
+type taskKey = string;
+
 type task('data) = 'data => Js.Promise.t(unit);
 type taskProvider('data) = unit => task('data);
 type taskCanceller = unit => unit;
@@ -32,18 +37,18 @@ type runnable('a) = {
 
 type registry('a) = {
   .
-  "sections": array(string),
+  "sections": array(section),
   "runnables": Js.Dict.t(runnable('a)),
 };
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external getAppKeys: unit => array(string) = "";
+external getAppKeys: unit => array(appKey) = "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
 external getRegistry: unit => registry('a) = "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external getRunnable: string => Js.Nullable.t(runnable('a)) = "";
+external getRunnable: appKey => option(runnable('a)) = "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
 external getSectionKeys: unit => array(string) = "";
@@ -53,29 +58,28 @@ external getSections: unit => Js.Dict.t(runnable('a)) = "";
 
 // multiple externals
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external registerComponent: (string, componentProvider('a)) => unit = "";
+external registerComponent: (appKey, componentProvider('a)) => unit = "";
 
 // multiple externals
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
 external registerComponentWithSection:
-  (string, componentProvider('a), string) => unit =
+  (appKey, componentProvider('a), section) => unit =
   "registerComponent";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
 external registerConfig: array(appConfig) => unit = "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external registerRunnable: (string, appParameters => unit) => string = "";
+external registerRunnable: (appKey, appParameters => unit) => string = "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external registerSection: (string, componentProvider('a)) => unit = "";
+external registerSection: (appKey, componentProvider('a)) => unit = "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external runApplication: (string, 'a) => unit = "";
+external runApplication: (appKey, 'a) => unit = "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external setWrapperComponentProvider:
-  Js.Nullable.t(wrapperComponentProvider('a, 'b)) => unit =
+external setWrapperComponentProvider: wrapperComponentProvider('a, 'b) => unit =
   "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
@@ -83,18 +87,18 @@ external unmountApplicationComponentAtRootTag: string => unit = "";
 
 // Android only
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external cancelHeadlessTask: (float, string) => unit = "";
+external cancelHeadlessTask: (taskId, taskKey) => unit = "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
 external registerCancellableHeadlessTask:
-  (string, taskProvider('data), taskCancelProvider) => unit =
+  (taskKey, taskProvider('data), taskCancelProvider) => unit =
   "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external registerHeadlessTask: (string, taskProvider('data)) => unit = "";
+external registerHeadlessTask: (taskKey, taskProvider('data)) => unit = "";
 
 [@bs.module "react-native"] [@bs.scope "AppRegistry"]
-external startHeadlessTask: (float, string, 'a) => unit = "";
+external startHeadlessTask: (taskId, taskKey, 'data) => unit = "";
 
 // react-native-web
 type app = {


### PR DESCRIPTION
Related to #561, these are almost complete, if not quite. What are still missing:
- `setComponentProviderInstrumentationHook`
- `createPerformanceLogger` (which is needed to create the hook)

(I still need to figure out how to bind to `createPerformanceLogger`, perhaps in a later PR?)

Some of the functions take an argument of type `Function`; that argument is passed `appParameters` (which is of type `any`), therefore I decided to define `Function` to be of type `appParameters => unit` and added a function `asAppParameters` to cast any type as `appParameters`. Hopefully that should be flexible enough. I don't believe the return type of `Function` matters at all, hence I chose to specify `unit` instead of some abstract type.