### PR TITLE
Use itemSeparatorComponent in flatList

### DIFF
--- a/reason-react-navigation-example/src/components/Timeline.re
+++ b/reason-react-navigation-example/src/components/Timeline.re
@@ -4,20 +4,13 @@ open Helpers;
 module TimelineItem = {
   [@react.component]
   let make = (~text, ~onPress) =>
-    <>
-      <TouchableOpacity
-        onPress
-        style=Style.(
-          style(~paddingHorizontal=16.->dp, ~paddingVertical=26.->dp, ())
-        )>
-        <Text> {text |> React.string} </Text>
-      </TouchableOpacity>
-      <View
-        style=Style.(
-          style(~borderBottomColor="#ddd", ~borderBottomWidth=1., ())
-        )
-      />
-    </>;
+    <TouchableOpacity
+      onPress
+      style=Style.(
+        style(~paddingHorizontal=16.->dp, ~paddingVertical=26.->dp, ())
+      )>
+      <Text> {text |> React.string} </Text>
+    </TouchableOpacity>;
 };
 
 module TimelineList = {
@@ -27,6 +20,13 @@ module TimelineList = {
       <FlatList
         data=Tweet.dummyTweets
         keyExtractor={({id}, _) => id}
+        _ItemSeparatorComponent={_ =>
+          <View
+            style=Style.(
+              style(~borderBottomColor="#ddd", ~borderBottomWidth=1., ())
+            )
+          />
+        }
         renderItem={props =>
           <TimelineItem
             onPress={_ =>

--- a/reason-react-navigation-example/src/components/Timeline.re
+++ b/reason-react-navigation-example/src/components/Timeline.re
@@ -13,6 +13,15 @@ module TimelineItem = {
     </TouchableOpacity>;
 };
 
+module ItemSeparator = {
+  [@react.component]
+  let make = () =>
+    <View
+      style=Style.(
+        style(~borderBottomColor="#ddd", ~borderBottomWidth=1., ())
+      )
+    />;
+};
 module TimelineList = {
   [@react.component]
   let make = (~navigation: Navigation.t) =>
@@ -20,13 +29,8 @@ module TimelineList = {
       <FlatList
         data=Tweet.dummyTweets
         keyExtractor={({id}, _) => id}
-        _ItemSeparatorComponent={_ =>
-          <View
-            style=Style.(
-              style(~borderBottomColor="#ddd", ~borderBottomWidth=1., ())
-            )
-          />
-        }
+        _ItemSeparatorComponent={_ => <ItemSeparator />}
+        _ListFooterComponent={_ => <ItemSeparator />}
         renderItem={props =>
           <TimelineItem
             onPress={_ =>


### PR DESCRIPTION
Thanks for this amazing work, so cool to be able to use ReasonML for building mobile apps :heart_eyes:

It's probably a matter or preferences, but I moved the horizontal separator used in the `Timeline` component from the `TimelineItem` to the `TimelineList` itself (using the `_ItemSeparatorComponent` prop).

Since this prop is specifically used for this purpose, I thought it would probably be a good idea to use it. One "nice" little improvement is that by using this prop, the separator is not displayed below the last item of the list (it's handled automatically by the `FlatList`).