### PR TITLE
Add bindings to react-native-netinfo

### DIFF
--- a/@reason-react-native/netinfo/README.md
+++ b/@reason-react-native/netinfo/README.md
@@ -1,0 +1,277 @@
+# BuckleScript bindings to React Native NetInfo
+
+[![Version](https://img.shields.io/npm/v/@reason-react-native/netinfo.svg)](https://www.npmjs.com/@reason-react-native/netinfo)
+
+These are BuckleScript bindings to
+[`React Native NetInfo`](https://github.com/react-native-community/react-native-netinfo),
+in Reason syntax. `NetInfo` has been removed from the React Native core with
+version 0.60, but as that release has breaking changes, this package is intended
+to work with React Native 0.59.x releases as well. Accordingly, to avoid
+namespace clashes with the `NetInfo` module in `reason-react-native` (as would
+happen with `open React Native`) and for consistency with other projects, the
+module has been named `ReactNativeNetInfo`.
+
+Version of these bindings follow that of the `React Native NetInfo` package.
+React Native versions 0.59.x and 0.60.x are supported, however
+[jetifier](https://github.com/mikehardy/jetifier) is required to support
+versions 0.59.x.
+
+| Version | React Native version                                                  | `npm` package for Reason bindings                                                          |
+| ------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| 4.1.x   | 0.60 or 0.59.x with [jetifier](https://github.com/mikehardy/jetifier) | [`@reason-react-native/netinfo`](https://www.npmjs.com/@reason-react-native/netinfo)       |
+| 3.2.x   | 0.59.x                                                                | [`reason-react-native-netinfo`](https://www.npmjs.com/package/reason-react-native-netinfo) |
+
+You may update your existing code using the `NetInfo` module of
+`reason-react-native` by replacing references to the `ReactNative.NetInfo`
+module with `ReactNativeNetInfo.Legacy`. However, do note that the new API is
+more straightforward.
+
+## Breaking Changes
+
+- Moved from
+  [sgny/reason-react-native-netinfo](https://github.com/sgny/reason-react-native-netinfo#readme).
+  `npm` package was previously named `reason-react-native-netinfo`. Please
+  update your dependencies accordingly.
+
+- The module is renamed to `ReactNativeNetInfo` (previously`CommunityNetInfo`).
+
+- Releases require use of [jetifier](https://github.com/mikehardy/jetifier) for
+  versions 0.59.x of React Native. You may continue to use
+  [`reason-react-native-netinfo`](https://www.npmjs.com/package/reason-react-native-netinfo)
+  version 3.2.x if you do not wish to use `jetifier`.
+
+## Installation
+
+With `yarn`:
+
+```shell
+yarn add @reason-react-native/netinfo
+```
+
+With `npm`:
+
+```shell
+npm install @reason-react-native/netinfo
+```
+
+Once package installation completes, `@react-native-community/netinfo` should be
+linked to your project. You may use the CLI as below:
+
+```shell
+react-native link @react-native-community/netinfo
+```
+
+Finally, `@reason-react-native/netinfo` should be added to `bs-dependencies` in
+`BuckleScript` configuration of the project (`bsconfig.json`). For example:
+
+```json
+{
+  ...
+  "bs-dependencies": ["reason-react", "reason-react-native", "@reason-react-native/netinfo"],
+  ...
+}
+```
+
+## Types
+
+### `netInfoStateType`
+
+Kind of the current network connection. Valid values are:
+
+| Value       | Platforms             | Connection State |
+| ----------- | --------------------- | ---------------- |
+| `none`      | Android, iOS, Windows | Not active       |
+| `unknown`   | Android, iOS, Windows | Undetermined     |
+| `cellular`  | Android, iOS, Windows | Active           |
+| `wifi`      | Android, iOS, Windows | Active           |
+| `bluetooth` | Android               | Active           |
+| `ethernet`  | Android, Windows      | Active           |
+| `wimax`     | Android               | Active           |
+| `vpn`       | Android               | Active           |
+| `other`     | Android, iOS, Windows | Active           |
+
+### `netInfoCellularGeneration`
+
+Cellular generation of the current network connection. Valid values are:
+
+| Value   | Notes                                                                               |
+| ------- | ----------------------------------------------------------------------------------- |
+| `net2g` | Inlined as "2g". Returned for CDMA, EDGE, GPRS and IDEN connections                 |
+| `net3g` | Inlined as "3g". Returned for EHRPD, EVDO, HSPA, HSUPA, HSDPA and UTMS connections. |
+| `net4g` | Inlined as "4g". Returned for HSPAP and LTE connections                             |
+
+### `details`
+
+```reason
+type details = {
+  .
+  "isConnectionExpensive": bool,
+  "cellularGeneration": Js.Nullable.t(netInfoCellularGeneration),
+};
+```
+
+### `netInfoState`
+
+```reason
+type netInfoState = {
+  .
+  "_type": netInfoStateType,
+  "isConnected": bool,
+  "details": Js.Null.t(details),
+};
+```
+
+`details` key will have value `Js.Null.empty` (`null`) when `_type` is `null` or
+`unknown`.
+
+If the `details` objects is not `null`, the `cellularGeneration` key within will
+
+- have value `Js.Nullable.undefined` when `_type` is `wifi`, `bluetooth`,
+  `ethernet`, `wimax`, `vpn` or `other`.
+- have value `Js.Nullable.null` if the connection is not cellular or its
+  generation cannot be determined.
+- be of type `netInfoCellularGeneration` only when `_type` is `cellular` and its
+  generation can be determined.
+
+## Methods
+
+### `fetch`
+
+To query the connection state, returns `netInfoState` wrapped in a `Promise`.
+
+```reason
+fetch: unit => Js.Promise.t(netInfoState) = "";
+```
+
+Below example demonstrates determination of the cellular connection generation,
+using this method.
+
+```reason
+React.useEffect0(() => {
+  Js.Promise.(
+    ReactNativeNetInfo.fetch()
+    |> then_(w =>
+         {
+           switch (w##details->Js.Null.toOption) {
+           | None => "Connection type is none or unknown"->Js.Console.warn
+           | Some(x) =>
+             let y = x##cellularGeneration;
+             switch (y->Js.Nullable.toOption) {
+             | None =>
+               if (y == Js.Nullable.undefined) {
+                 "Connection type is wifi, bluetooth, ethernet, wimax, vpn or other"
+                 ->Js.Console.warn;
+               } else {
+                 "Connection generation unknown"->Js.Console.warn;
+               }
+             | Some(z) =>
+               if (z == ReactNativeNetInfo.net2G) {
+                 "2G connection"->Js.Console.warn;
+               } else if (z == ReactNativeNetInfo.net3G) {
+                 "3G connection"->Js.Console.warn;
+               } else {
+                 "4G connection"->Js.Console.warn;
+               }
+             };
+           };
+         }
+         ->resolve
+       )
+    |> catch(err => "error"->Js.Console.warn->resolve)
+    |> ignore
+  );
+  None;
+});
+```
+
+### `addEventListener`
+
+To subscribe to the connection state; accepts a listener of type
+`netInfoState => unit` and returns an unsubscribe method of type `unit => unit`.
+The listener will be called once following subscription and each time connection
+state changes.
+
+```reason
+addEventListener: (netInfoState => unit) => t;
+```
+
+where
+
+```reason
+type t = unit => unit
+```
+
+Below example demonstrates subscribing to changes in connection state:
+
+```reason
+React.useEffect0(() => {
+  let remove =
+    ReactNativeNetInfo.addEventListener(w =>
+      (
+        switch (w##details->Js.Null.toOption) {
+        | None => "Connection type is none or unknown"
+        | Some(x) =>
+          let y = x##cellularGeneration;
+          switch (y->Js.Nullable.toOption) {
+          | None =>
+            if (y == Js.Nullable.undefined) {
+              "Connection type is wifi, bluetooth, ethernet, wimax, vpn or other";
+            } else {
+              "Connection generation unknown";
+            }
+          | Some(z) =>
+            if (z == ReactNativeNetInfo.net2G) {
+              "2G connection";
+            } else if (z == ReactNativeNetInfo.net3G) {
+              "3G connection";
+            } else {
+              "4G connection";
+            }
+          };
+        }
+      )
+      ->Js.Console.warn
+    );
+  Js.Console.warn(remove);
+  Some(() => remove());
+});
+```
+
+### `useNetInfo`
+
+This method returns a React Hook with type `netInfoState`
+
+```reason
+useNetInfo: unit => netInfoState
+```
+
+Below example demonstrates its use within a `Text` component:
+
+```reason
+<Text>
+  (
+    switch (ReactNativeNetInfo.useNetInfo()##details->Js.Null.toOption) {
+    | None => "Connection type is none or unknown"
+    | Some(x) =>
+      let y = x##cellularGeneration;
+      switch (y->Js.Nullable.toOption) {
+      | None =>
+        if (y == Js.Nullable.undefined) {
+          "Connection type is wifi, bluetooth, ethernet, wimax, vpn or other";
+        } else {
+          "Connection generation unknown";
+        }
+      | Some(z) =>
+        if (z == ReactNativeNetInfo.net2G) {
+          "2G connection";
+        } else if (z == ReactNativeNetInfo.net3G) {
+          "3G connection";
+        } else {
+          "4G connection";
+        }
+      };
+    }
+  )
+  ->React.string
+</Text>
+```

--- a/@reason-react-native/netinfo/bsconfig.json
+++ b/@reason-react-native/netinfo/bsconfig.json
@@ -1,0 +1,20 @@
+{
+  "name": "@reason-react-native/netinfo",
+  "refmt": 3,
+  "reason": {
+    "react-jsx": 3
+  },
+  "package-specs": {
+    "module": "commonjs",
+    "in-source": true
+  },
+  "suffix": ".bs.js",
+  "sources": [
+    {
+      "dir": "src",
+      "subdirs": false
+    }
+  ],
+  "bsc-flags": ["-bs-no-version-header", "-warn-error @a"],
+  "bs-dependencies": []
+}

--- a/@reason-react-native/netinfo/package.json
+++ b/@reason-react-native/netinfo/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@reason-react-native/netinfo",
+  "version": "4.1.0",
+  "author": "sgny (https://github.com/sgny)",
+  "repository": "https://github.com/reasonml-community/reason-react-native.git",
+  "license": "MIT",
+  "keywords": [
+    "reason",
+    "reasonml",
+    "bucklescript",
+    "react-native",
+    "react-native-netinfo"
+  ],
+  "scripts": {
+    "clean": "bsb -clean-world",
+    "start": "bsb -make-world -w",
+    "build": "bsb -make-world",
+    "clean-build": "bsb -clean-world -make-world"
+  },
+  "peerDependencies": {
+    "bs-platform": "~5.0.4",
+    "react-native": "~0.59.9",
+    "reason-react": "^0.7.0",
+    "reason-react-native": "^0.60.0"
+  },
+  "dependencies": {
+    "@react-native-community/netinfo": "~4.1.0"
+  }
+}

--- a/@reason-react-native/netinfo/src/ReactNativeNetInfo.bs.js
+++ b/@reason-react-native/netinfo/src/ReactNativeNetInfo.bs.js
@@ -1,0 +1,15 @@
+'use strict';
+
+
+var ConnectionType = /* module */[];
+
+var EffectiveConnectionType = /* module */[];
+
+var IsConnected = /* module */[];
+
+var Legacy = /* module */[/* IsConnected */IsConnected];
+
+exports.ConnectionType = ConnectionType;
+exports.EffectiveConnectionType = EffectiveConnectionType;
+exports.Legacy = Legacy;
+/* No side effect */

--- a/@reason-react-native/netinfo/src/ReactNativeNetInfo.re
+++ b/@reason-react-native/netinfo/src/ReactNativeNetInfo.re
@@ -1,0 +1,142 @@
+type t = unit => unit;
+
+type netInfoStateType = string;
+
+[@bs.inline]
+let none = "none";
+
+[@bs.inline]
+let unknown = "unknown";
+
+[@bs.inline]
+let cellular = "cellular";
+
+[@bs.inline]
+let wifi = "wifi";
+
+[@bs.inline]
+let bluetooth = "bluetooth";
+
+[@bs.inline]
+let ethernet = "ethernet";
+
+[@bs.inline]
+let wimax = "wimax";
+
+[@bs.inline]
+let vpn = "vpn";
+
+[@bs.inline]
+let other = "other";
+
+type netInfoCellularGeneration = string;
+
+[@bs.inline]
+let net2G = "2g";
+
+[@bs.inline]
+let net3G = "3g";
+
+[@bs.inline]
+let net4G = "4g";
+
+type details = {
+  .
+  "isConnectionExpensive": bool,
+  "cellularGeneration": Js.Nullable.t(netInfoCellularGeneration),
+};
+
+type netInfoState = {
+  .
+  "_type": netInfoStateType,
+  "isConnected": bool,
+  "details": Js.Null.t(details),
+};
+
+[@bs.module "@react-native-community/netinfo"]
+external fetch: unit => Js.Promise.t(netInfoState) = "";
+
+[@bs.module "@react-native-community/netinfo"]
+external addEventListener: (netInfoState => unit) => t = "";
+
+[@bs.module "@react-native-community/netinfo"]
+external useNetInfo: unit => netInfoState = "";
+
+module ConnectionType = {
+  type t = string;
+
+  [@bs.inline]
+  let bluetooth = "bluetooth";
+
+  [@bs.inline]
+  let cellular = "cellular";
+
+  [@bs.inline]
+  let ethernet = "ethernet";
+
+  [@bs.inline]
+  let unknown = "unknown";
+
+  [@bs.inline]
+  let wifi = "wifi";
+
+  [@bs.inline]
+  let wimax = "wimax";
+};
+
+module EffectiveConnectionType = {
+  type t = string;
+
+  [@bs.inline]
+  let net2G = "2g";
+
+  [@bs.inline]
+  let net3G = "3g";
+
+  [@bs.inline]
+  let net4G = "4g";
+
+  [@bs.inline]
+  let unknown = "unknown";
+};
+
+type info = {
+  .
+  "_type": ConnectionType.t,
+  "effectiveType": EffectiveConnectionType.t,
+};
+
+type remove = {. "remove": unit => unit};
+
+module Legacy = {
+  [@bs.module "@react-native-community/netinfo"]
+  external addEventListener:
+    ([@bs.string] [ | `connectionChange], info => unit) => remove =
+    "";
+
+  [@bs.module "@react-native-community/netinfo"]
+  external removeEventListener:
+    ([@bs.string] [ | `connectionChange], info => unit) => unit =
+    "";
+
+  [@bs.module "@react-native-community/netinfo"]
+  external isConnectionExpensive: unit => Js.Promise.t(bool) = "";
+
+  [@bs.module "@react-native-community/netinfo"]
+  external getConnectionInfo: unit => Js.Promise.t(info) = "";
+
+  module IsConnected = {
+    [@bs.module "@react-native-community/netinfo"] [@bs.scope "isConnected"]
+    external addEventListener:
+      ([@bs.string] [ | `connectionChange], bool => unit) => remove =
+      "";
+
+    [@bs.module "@react-native-community/netinfo"] [@bs.scope "isConnected"]
+    external removeEventListener:
+      ([@bs.string] [ | `connectionChange], bool => unit) => unit =
+      "";
+
+    [@bs.module "@react-native-community/netinfo"] [@bs.scope "isConnected"]
+    external fetch: unit => Js.Promise.t(bool) = "";
+  };
+};

--- a/@reason-react-native/netinfo/src/ReactNativeNetInfo.rei
+++ b/@reason-react-native/netinfo/src/ReactNativeNetInfo.rei
@@ -1,0 +1,142 @@
+type t = unit => unit;
+
+type netInfoStateType;
+
+[@bs.inline "none"]
+let none: netInfoStateType;
+
+[@bs.inline "unknown"]
+let unknown: netInfoStateType;
+
+[@bs.inline "cellular"]
+let cellular: netInfoStateType;
+
+[@bs.inline "wifi"]
+let wifi: netInfoStateType;
+
+[@bs.inline "bluetooth"]
+let bluetooth: netInfoStateType;
+
+[@bs.inline "ethernet"]
+let ethernet: netInfoStateType;
+
+[@bs.inline "wimax"]
+let wimax: netInfoStateType;
+
+[@bs.inline "vpn"]
+let vpn: netInfoStateType;
+
+[@bs.inline "other"]
+let other: netInfoStateType;
+
+type netInfoCellularGeneration;
+
+[@bs.inline "2g"]
+let net2G: netInfoCellularGeneration;
+
+[@bs.inline "3g"]
+let net3G: netInfoCellularGeneration;
+
+[@bs.inline "4g"]
+let net4G: netInfoCellularGeneration;
+
+type details = {
+  .
+  "isConnectionExpensive": bool,
+  "cellularGeneration": Js.Nullable.t(netInfoCellularGeneration),
+};
+
+type netInfoState = {
+  .
+  "_type": netInfoStateType,
+  "isConnected": bool,
+  "details": Js.Null.t(details),
+};
+
+[@bs.module "@react-native-community/netinfo"]
+external fetch: unit => Js.Promise.t(netInfoState) = "";
+
+[@bs.module "@react-native-community/netinfo"]
+external addEventListener: (netInfoState => unit) => t = "";
+
+[@bs.module "@react-native-community/netinfo"]
+external useNetInfo: unit => netInfoState = "";
+
+module ConnectionType: {
+  type t;
+
+  [@bs.inline "bluetooth"]
+  let bluetooth: t;
+
+  [@bs.inline "cellular"]
+  let cellular: t;
+
+  [@bs.inline "ethernet"]
+  let ethernet: t;
+
+  [@bs.inline "unknown"]
+  let unknown: t;
+
+  [@bs.inline "wifi"]
+  let wifi: t;
+
+  [@bs.inline "wimax"]
+  let wimax: t;
+};
+
+module EffectiveConnectionType: {
+  type t;
+
+  [@bs.inline "2g"]
+  let net2G: t;
+
+  [@bs.inline "3g"]
+  let net3G: t;
+
+  [@bs.inline "4g"]
+  let net4G: t;
+
+  [@bs.inline "unknown"]
+  let unknown: t;
+};
+
+type info = {
+  .
+  "effectiveType": EffectiveConnectionType.t,
+  "_type": ConnectionType.t,
+};
+
+type remove = {. "remove": unit => unit};
+
+module Legacy: {
+  [@bs.module "@react-native-community/netinfo"]
+  external addEventListener:
+    ([@bs.string] [ | `connectionChange], info => unit) => remove =
+    "";
+
+  [@bs.module "@react-native-community/netinfo"]
+  external removeEventListener:
+    ([@bs.string] [ | `connectionChange], info => unit) => unit =
+    "";
+
+  [@bs.module "@react-native-community/netinfo"]
+  external isConnectionExpensive: unit => Js.Promise.t(bool) = "";
+
+  [@bs.module "@react-native-community/netinfo"]
+  external getConnectionInfo: unit => Js.Promise.t(info) = "";
+
+  module IsConnected: {
+    [@bs.module "@react-native-community/netinfo"] [@bs.scope "isConnected"]
+    external addEventListener:
+      ([@bs.string] [ | `connectionChange], bool => unit) => remove =
+      "";
+
+    [@bs.module "@react-native-community/netinfo"] [@bs.scope "isConnected"]
+    external removeEventListener:
+      ([@bs.string] [ | `connectionChange], bool => unit) => unit =
+      "";
+
+    [@bs.module "@react-native-community/netinfo"] [@bs.scope "isConnected"]
+    external fetch: unit => Js.Promise.t(bool) = "";
+  };
+};


### PR DESCRIPTION
I have moved the bindings over from my repo, renamed the module and updated documentation accordingly.

I believe they are ready to be published but the version shields should probably be removed for that.
