### PR TITLE
@reason-react-native/netinfo: prepare initial release

### DIFF
--- a/@reason-react-native/netinfo/.gitignore
+++ b/@reason-react-native/netinfo/.gitignore
@@ -1,0 +1,5 @@
+# Ocaml / Reason / BuckleScript artifacts
+.bsb.lock
+**/lib/bs
+**/lib/ocaml
+**/.merlin

--- a/@reason-react-native/netinfo/CHANGELOG.md
+++ b/@reason-react-native/netinfo/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## 4.1.0
+
+### Breaking Changes
+
+- Moved from
+  [sgny/reason-react-native-netinfo](https://github.com/sgny/reason-react-native-netinfo#readme).
+  `npm` package was previously named `reason-react-native-netinfo`. Please
+  update your dependencies accordingly. You may update your existing code using
+  the `NetInfo` module of `reason-react-native` by replacing references to the
+  `ReactNative.NetInfo` module with `ReactNativeNetInfo.Legacy`. However, do
+  note that the new API is more straightforward.
+
+- The module is renamed to `ReactNativeNetInfo` (previously`CommunityNetInfo`).
+
+- Releases require use of [jetifier](https://github.com/mikehardy/jetifier) for
+  versions 0.59.x of React Native. You may continue to use
+  [`reason-react-native-netinfo`](https://www.npmjs.com/package/reason-react-native-netinfo)
+  version 3.2.x if you do not wish to use `jetifier`.
+
+## 3.x
+
+See
+[sgny/reason-react-native-netinfo](https://github.com/sgny/reason-react-native-netinfo/tree/3.2.4])

--- a/@reason-react-native/netinfo/README.md
+++ b/@reason-react-native/netinfo/README.md
@@ -1,80 +1,64 @@
-# BuckleScript bindings to React Native NetInfo
+# BuckleScript bindings to `@react-native-community/netinfo`
 
 [![Version](https://img.shields.io/npm/v/@reason-react-native/netinfo.svg)](https://www.npmjs.com/@reason-react-native/netinfo)
 
-These are BuckleScript bindings to
-[`React Native NetInfo`](https://github.com/react-native-community/react-native-netinfo),
-in Reason syntax. `NetInfo` has been removed from the React Native core with
-version 0.60, but as that release has breaking changes, this package is intended
-to work with React Native 0.59.x releases as well. Accordingly, to avoid
-namespace clashes with the `NetInfo` module in `reason-react-native` (as would
-happen with `open React Native`) and for consistency with other projects, the
-module has been named `ReactNativeNetInfo`.
+Reason / BuckleScript bindings for
+[`@react-native-community/netinfo`](https://github.com/react-native-community/react-native-netinfo)
+(exposed as `ReactNativeNetInfo`).
 
-Version of these bindings follow that of the `React Native NetInfo` package.
-React Native versions 0.59.x and 0.60.x are supported, however
-[jetifier](https://github.com/mikehardy/jetifier) is required to support
-versions 0.59.x.
+## Support
 
-| Version | React Native version                                                  | `npm` package for Reason bindings                                                          |
-| ------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| 4.1.x   | 0.60 or 0.59.x with [jetifier](https://github.com/mikehardy/jetifier) | [`@reason-react-native/netinfo`](https://www.npmjs.com/@reason-react-native/netinfo)       |
-| 3.2.x   | 0.59.x                                                                | [`reason-react-native-netinfo`](https://www.npmjs.com/package/reason-react-native-netinfo) |
+`@reason-react-native/netinfo` X.y._ means it's compatible with
+`@react-native-community/netinfo` X.y._
 
-You may update your existing code using the `NetInfo` module of
-`reason-react-native` by replacing references to the `ReactNative.NetInfo`
-module with `ReactNativeNetInfo.Legacy`. However, do note that the new API is
-more straightforward.
+| version | react-native version |
+| ------- | -------------------- |
+| 4.1.0+  | 0.60.0+              |
 
-## Breaking Changes
-
-- Moved from
-  [sgny/reason-react-native-netinfo](https://github.com/sgny/reason-react-native-netinfo#readme).
-  `npm` package was previously named `reason-react-native-netinfo`. Please
-  update your dependencies accordingly.
-
-- The module is renamed to `ReactNativeNetInfo` (previously`CommunityNetInfo`).
-
-- Releases require use of [jetifier](https://github.com/mikehardy/jetifier) for
-  versions 0.59.x of React Native. You may continue to use
-  [`reason-react-native-netinfo`](https://www.npmjs.com/package/reason-react-native-netinfo)
-  version 3.2.x if you do not wish to use `jetifier`.
+For 0.59-, you should use
+[`jetify -r`](https://github.com/mikehardy/jetifier/blob/master/README.md#to-reverse-jetify--convert-node_modules-dependencies-to-support-libraries).
 
 ## Installation
 
 With `yarn`:
 
-```shell
+```console
 yarn add @reason-react-native/netinfo
 ```
 
 With `npm`:
 
-```shell
+```console
 npm install @reason-react-native/netinfo
 ```
 
-Once package installation completes, `@react-native-community/netinfo` should be
-linked to your project. You may use the CLI as below:
+If you use React Native 0.60, `@react-native-community/netinfo` should be linked
+to your project:
 
-```shell
+```console
 react-native link @react-native-community/netinfo
 ```
 
 Finally, `@reason-react-native/netinfo` should be added to `bs-dependencies` in
 `BuckleScript` configuration of the project (`bsconfig.json`). For example:
 
-```json
+```diff
 {
-  ...
-  "bs-dependencies": ["reason-react", "reason-react-native", "@reason-react-native/netinfo"],
-  ...
+  //...
+  "bs-dependencies": [
+    "reason-react",
+    "reason-react-native",
++    "@reason-react-native/netinfo"
+  ],
+  //...
 }
 ```
 
-## Types
+## Usage
 
-### `netInfoStateType`
+### Types
+
+#### `netInfoStateType`
 
 Kind of the current network connection. Valid values are:
 
@@ -90,7 +74,7 @@ Kind of the current network connection. Valid values are:
 | `vpn`       | Android               | Active           |
 | `other`     | Android, iOS, Windows | Active           |
 
-### `netInfoCellularGeneration`
+#### `netInfoCellularGeneration`
 
 Cellular generation of the current network connection. Valid values are:
 
@@ -100,7 +84,7 @@ Cellular generation of the current network connection. Valid values are:
 | `net3g` | Inlined as "3g". Returned for EHRPD, EVDO, HSPA, HSUPA, HSDPA and UTMS connections. |
 | `net4g` | Inlined as "4g". Returned for HSPAP and LTE connections                             |
 
-### `details`
+#### `details`
 
 ```reason
 type details = {
@@ -110,7 +94,7 @@ type details = {
 };
 ```
 
-### `netInfoState`
+#### `netInfoState`
 
 ```reason
 type netInfoState = {
@@ -133,9 +117,9 @@ If the `details` objects is not `null`, the `cellularGeneration` key within will
 - be of type `netInfoCellularGeneration` only when `_type` is `cellular` and its
   generation can be determined.
 
-## Methods
+### Methods
 
-### `fetch`
+#### `fetch`
 
 To query the connection state, returns `netInfoState` wrapped in a `Promise`.
 
@@ -184,7 +168,7 @@ React.useEffect0(() => {
 });
 ```
 
-### `addEventListener`
+#### `addEventListener`
 
 To subscribe to the connection state; accepts a listener of type
 `netInfoState => unit` and returns an unsubscribe method of type `unit => unit`.
@@ -237,7 +221,7 @@ React.useEffect0(() => {
 });
 ```
 
-### `useNetInfo`
+#### `useNetInfo`
 
 This method returns a React Hook with type `netInfoState`
 

--- a/@reason-react-native/netinfo/package.json
+++ b/@reason-react-native/netinfo/package.json
@@ -9,21 +9,30 @@
     "reasonml",
     "bucklescript",
     "react-native",
-    "react-native-netinfo"
+    "react-native-netinfo",
+    "netinfo"
+  ],
+  "files": [
+    "*",
+    "!.DS_Store",
+    "!**/*.bs.js",
+    "!.merlin",
+    "!lib/bs",
+    "!lib/ocaml"
   ],
   "scripts": {
-    "clean": "bsb -clean-world",
     "start": "bsb -make-world -w",
     "build": "bsb -make-world",
-    "clean-build": "bsb -clean-world -make-world"
+    "clean": "bsb -clean-world",
+    "test": "bsb -clean-world -make-world"
+  },
+  "devDependencies": {
+    "bs-platform": "^5.0.4",
+    "reason-react": "^0.7.0",
+    "reason-react-native": "^0.60.0",
+    "@react-native-community/netinfo": "^4.1.0"
   },
   "peerDependencies": {
-    "bs-platform": "~5.0.4",
-    "react-native": "~0.59.9",
-    "reason-react": "^0.7.0",
-    "reason-react-native": "^0.60.0"
-  },
-  "dependencies": {
-    "@react-native-community/netinfo": "~4.1.0"
+    "@react-native-community/netinfo": "^4.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "bs-react-native-example",
     "reason-react-navigation",
     "reason-react-navigation-example",
+    "@reason-react-native/*",
     "website"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1601,6 +1601,11 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-2.0.10.tgz#d28a446352e75754b78509557988359133cdbcca"
   integrity sha512-NrIzyLe0eSbhgMnHl2QdSEhaA7yXh6p9jzMomfUa//hoTXE+xbObGDdiWWSQm2bnXnZJg8XCU3AB9qzvqcuLnA==
 
+"@react-native-community/netinfo@^4.1.0":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-4.1.5.tgz#4bb44842db6a1a18f00a0f061b0e3dcc638f67dd"
+  integrity sha512-lagdZr9UiVAccNXYfTEj+aUcPCx9ykbMe9puffeIyF3JsRuMmlu3BjHYx1klUHX7wNRmFNC8qVP0puxUt1sZ0A==
+
 "@react-navigation/core@~3.4.1":
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-3.4.2.tgz#bec563e94fde40fbab3730cdc97f22afbb2a1498"


### PR DESCRIPTION
I changed the following:

- move what's for migration to a new CHANGELOG file
- simplified support table to only be "up to date" with current state of the module
- adjusted some npm stuff (correct ignore to not publish build artifacts, following https://github.com/reasonml-community/reason-react-native/commit/30f96277072b0f726cd0dd12a33eba9a6b53f46e)
- added command & stuff so netinfo is compiled/tested with global test command (= CI check)