### PR TITLE
async-storage bindings

### DIFF
--- a/@reason-react-native/async-storage/.gitignore
+++ b/@reason-react-native/async-storage/.gitignore
@@ -1,0 +1,5 @@
+# Ocaml / Reason / BuckleScript artifacts
+.bsb.lock
+**/lib/bs
+**/lib/ocaml
+**/.merlin

--- a/@reason-react-native/async-storage/bsconfig.json
+++ b/@reason-react-native/async-storage/bsconfig.json
@@ -1,0 +1,20 @@
+{
+  "name": "@reason-react-native/async-storage",
+  "refmt": 3,
+  "reason": {
+    "react-jsx": 3
+  },
+  "package-specs": {
+    "module": "commonjs",
+    "in-source": true
+  },
+  "suffix": ".bs.js",
+  "sources": [
+    {
+      "dir": "src",
+      "subdirs": false
+    }
+  ],
+  "bsc-flags": ["-bs-no-version-header", "-warn-error @a"],
+  "bs-dependencies": []
+}

--- a/@reason-react-native/async-storage/package.json
+++ b/@reason-react-native/async-storage/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@reason-react-native/async-storage",
+  "version": "0.0.1",
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "tatchi (https://github.com/tatchi)",
+  "repository": "https://github.com/reasonml-community/reason-react-native.git",
+  "license": "MIT",
+  "keywords": [
+    "reason",
+    "reasonml",
+    "bucklescript",
+    "react-native",
+    "react-native-async-storage",
+    "async-storage"
+  ],
+  "files": [
+    "*",
+    "!.DS_Store",
+    "!**/*.bs.js",
+    "!.merlin",
+    "!lib/bs",
+    "!lib/ocaml"
+  ],
+  "scripts": {
+    "start": "bsb -make-world -w",
+    "build": "bsb -make-world",
+    "clean": "bsb -clean-world",
+    "test": "bsb -clean-world -make-world"
+  },
+  "devDependencies": {
+    "bs-platform": "^5.0.4",
+    "reason-react": "^0.7.0",
+    "reason-react-native": "^0.60.0",
+    "@react-native-community/async-storage": "^1.6.1"
+  },
+  "peerDependencies": {
+    "@react-native-community/async-storage": "^1.6.1"
+  }
+}

--- a/@reason-react-native/async-storage/src/ReactNativeAsyncStorage.bs.js
+++ b/@reason-react-native/async-storage/src/ReactNativeAsyncStorage.bs.js
@@ -1,0 +1,1 @@
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/@reason-react-native/async-storage/src/ReactNativeAsyncStorage.re
+++ b/@reason-react-native/async-storage/src/ReactNativeAsyncStorage.re
@@ -1,0 +1,37 @@
+[@bs.scope "default"] [@bs.module "@react-native-community/async-storage"]
+external getItem: string => Js.Promise.t(Js.Null.t(string)) = "getItem";
+
+[@bs.scope "default"] [@bs.module "@react-native-community/async-storage"]
+external setItem: (string, string) => Js.Promise.t(unit) = "setItem";
+
+[@bs.scope "default"] [@bs.module "@react-native-community/async-storage"]
+external removeItem: string => Js.Promise.t(unit) = "removeItem";
+
+[@bs.scope "default"] [@bs.module "@react-native-community/async-storage"]
+external mergeItem: (string, string) => Js.Promise.t(unit) = "mergeItem";
+
+[@bs.scope "default"] [@bs.module "@react-native-community/async-storage"]
+external clear: unit => Js.Promise.t(unit) = "clear";
+
+[@bs.scope "default"] [@bs.module "@react-native-community/async-storage"]
+external getAllKeys: unit => Js.Promise.t(Js.Null.t(array(string))) =
+  "getAllKeys";
+
+[@bs.scope "default"] [@bs.module "@react-native-community/async-storage"]
+external multiGet:
+  array(string) => Js.Promise.t(array((string, Js.Null.t(string)))) =
+  "multiGet";
+
+[@bs.scope "default"] [@bs.module "@react-native-community/async-storage"]
+external multiSet: array((string, string)) => Js.Promise.t(unit) =
+  "multiSet";
+
+[@bs.scope "default"] [@bs.module "@react-native-community/async-storage"]
+external multiMerge: array((string, string)) => Js.Promise.t(unit) =
+  "multiMerge";
+
+[@bs.scope "default"] [@bs.module "@react-native-community/async-storage"]
+external multiRemove: array(string) => Js.Promise.t(unit) = "multiRemove";
+
+[@bs.scope "default"] [@bs.module "@react-native-community/async-storage"]
+external flushGetRequests: unit => unit = "flushGetRequests";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,6 +1556,11 @@
     remark-toc "^4.0.0"
     unified "^7.1.0"
 
+"@react-native-community/async-storage@^1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.6.1.tgz#19be07fc1d65c77bdeb20f46108ba12076aad1c5"
+  integrity sha512-1WA28xfdhG+unkTEk/lXnqI2izv6belo0CYw7UdvaeHm8TIYT6eTmIIdGR7oiCa2xSKEnaPQqRMH6h7gyLNbww==
+
 "@react-native-community/cli@^1.2.1":
   version "1.9.11"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-1.9.11.tgz#b868b17201057b9cd16a3a20c30561176071f21a"


### PR DESCRIPTION
Bindings for the [async-storage](https://github.com/react-native-community/async-storage) package. (#594)

I have implemented them based on the (current ones)[https://github.com/reasonml-community/reason-react-native/blob/master/reason-react-native/src/apis/AsyncStorage.re] but have slightly modified two of them:

- multiMerge: use `array((string, string))` instead of `array(array(string))`. Since we always pass an array of arrays containing 2 elements (key and value), I think tuple would be a better fit (like it's already done for the `multiSet)`.
- multiGet: also replaced the double arrays to an array of tuples (for the same reason). Furthermore and according to my tests, we never get back a `null` value. If a `key` does not exist, this key will still exist in the returned array but only the corresponding `value` will be `null`. That still seems strange since that's not what the doc mention: https://github.com/react-native-community/async-storage/blob/LEGACY/docs/API.md#multiget

Except from that, the rest should be the same.

I still need to create the binding for the [useAsyncStorage](https://github.com/react-native-community/async-storage/blob/LEGACY/docs/API.md#useasyncstorage) hooks. I will address that later on.